### PR TITLE
Refactor KMP Plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     implementation(Deps.chrisBanes.insetterWidgets)
 
     implementation(Deps.google.hilt)
-    kapt(KaptDeps.google.hilt)
+//    kapt(KaptDeps.google.hilt)
     implementation(Deps.google.material)
     implementation(Deps.google.mlKitBarcodeScanning)
     implementation(Deps.google.zxing)
@@ -111,7 +111,7 @@ dependencies {
     implementation(Deps.square.okhttp)
     implementation(Deps.square.okhttpLogging)
     implementation(Deps.square.moshi)
-    kapt(KaptDeps.square.moshiCodegen)
+//    kapt(KaptDeps.square.moshiCodegen)
     implementation(Deps.square.sqlDelightAndroid)
     implementation(Deps.square.sqlDelightAndroidPaging3)
     implementation(Deps.square.sqlDelightCoroutines)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,8 +81,7 @@ dependencies {
     implementation(Deps.androidx.securityCrypto)
     implementation(Deps.androidx.viewBinding)
 
-    implementation(Deps.chrisBanes.insetter)
-    implementation(Deps.chrisBanes.insetterWidgets)
+    implementation(Deps.insetter)
 
     implementation(Deps.google.hilt)
 //    kapt(KaptDeps.google.hilt)

--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,6 @@ buildscript {
     }
 }
 
-plugins {
-    id("com.github.ben-manes.versions")
-}
-
 allprojects {
     repositories {
         mavenCentral()
@@ -48,6 +44,7 @@ task clean(type: Delete) {
 ////////////////////////////////////////////////////////////////////////////
 /// Gradle Versions: https://github.com/ben-manes/gradle-versions-plugin ///
 ////////////////////////////////////////////////////////////////////////////
+apply plugin: "com.github.ben-manes.versions"
 
 def isNonStable = { String version ->
     def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { it -> version.toUpperCase().contains(it) }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,6 +7,12 @@ plugins {
     id("dependencies")
 }
 
+repositories {
+    mavenCentral()
+    google()
+    gradlePluginPortal()
+}
+
 System.setProperty("GRADLE_ANDROID", Plugins.android.gradle)
 System.setProperty("GRADLE_ANDROIDX_NAVIGATION_SAFEARGS", Plugins.androidx.navigation.safeArgs)
 System.setProperty("GRADLE_GOOGLE_HILT", Plugins.google.hilt)
@@ -18,7 +24,3 @@ System.setProperty("GRADLE_SERIALIZATION", Plugins.kotlin.serialization)
 System.setProperty("GRADLE_MAVEN_PUBLISH", Plugins.mavenPublish)
 System.setProperty("GRADLE_SQUARE_EXHAUSTIVE", Plugins.square.exhaustive)
 System.setProperty("GRADLE_SQUARE_SQLDELIGHT", Plugins.square.sqlDelight)
-
-repositories {
-    gradlePluginPortal()
-}

--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
@@ -11,13 +11,12 @@ object Versions {
 
     const val androidGradle         = "4.2.2"
     const val arch                  = "2.1.0"
-    const val camera                = "1.1.0-alpha06"
-    const val cameraView            = "1.0.0-alpha26"
+    const val camera                = "1.1.0-alpha07"
+    const val cameraView            = "1.0.0-alpha27"
     const val coil                  = "1.3.0"
     const val coroutines            = "1.5.1"
-    const val insetter              = "0.5.0"
     const val lifecycle             = "2.3.1"
-    const val hilt                  = "2.37"
+    const val hilt                  = "2.38"
     const val hiltJetpack           = "1.0.0-alpha03"
     const val kotlin                = "1.5.21"
     const val moshi                 = "1.12.0"
@@ -33,7 +32,7 @@ object Deps {
     object androidx {
 
         const val annotation        = "androidx.annotation:annotation:1.2.0"
-        const val appCompat         = "androidx.appcompat:appcompat:1.3.0"
+        const val appCompat         = "androidx.appcompat:appcompat:1.3.1"
 
         object camera {
 
@@ -61,7 +60,7 @@ object Deps {
 
         }
 
-        const val media             = "androidx.media:media:1.3.1"
+        const val media             = "androidx.media:media:1.4.0"
 
         object navigation {
 
@@ -70,19 +69,14 @@ object Deps {
 
         }
 
-        const val paging3               = "androidx.paging:paging-runtime:3.0.0"
+        const val paging3               = "androidx.paging:paging-runtime:3.0.1"
         const val recyclerView          = "androidx.recyclerview:recyclerview:1.2.1"
         const val securityCrypto        = "androidx.security:security-crypto:1.1.0-alpha03"
         const val viewBinding           = "androidx.databinding:viewbinding:${Versions.androidGradle}"
 
     }
 
-    object chrisBanes {
-
-        const val insetter              = "dev.chrisbanes.insetter:insetter:${Versions.insetter}"
-        const val insetterWidgets       = "dev.chrisbanes.insetter:insetter-widgets:${Versions.insetter}"
-
-    }
+    const val insetter                  = "dev.chrisbanes.insetter:insetter:0.6.0"
 
     object google {
 
@@ -179,7 +173,7 @@ object Plugins {
     }
 
     const val gradleVersions    = "com.github.ben-manes:gradle-versions-plugin:0.39.0"
-    const val intellijGradle    = "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.18"
+    const val intellijGradle    = "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.26"
 
     object kotlin {
 

--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
@@ -4,26 +4,27 @@ package io.matthewnelson.components.dependencies
 
 object Versions {
 
-    const val buildTools                = "30.0.3"
-    const val compileSdk                = 30
-    const val minSdk                    = 16
+    const val buildTools            = "30.0.3"
+    const val compileSdk            = 30
+    const val minSdk16              = 16
+    const val minSdk23              = 23
 
-    internal const val androidGradle    = "4.2.2"
-    internal const val arch             = "2.1.0"
-    internal const val camera           = "1.1.0-alpha06"
-    internal const val cameraView       = "1.0.0-alpha26"
-    internal const val coil             = "1.3.0"
-    internal const val coroutines       = "1.5.1"
-    internal const val insetter         = "0.5.0"
-    internal const val lifecycle        = "2.3.1"
-    internal const val hilt             = "2.37"
-    internal const val hiltJetpack      = "1.0.0-alpha03"
-    internal const val kotlin           = "1.5.21"
-    internal const val moshi            = "1.12.0"
-    internal const val navigation       = "2.3.5"
-    internal const val okhttp           = "4.9.1"
-    internal const val sqlDelight       = "1.5.1"
-    internal const val toplAndroid      = "2.1.1"
+    const val androidGradle         = "4.2.2"
+    const val arch                  = "2.1.0"
+    const val camera                = "1.1.0-alpha06"
+    const val cameraView            = "1.0.0-alpha26"
+    const val coil                  = "1.3.0"
+    const val coroutines            = "1.5.1"
+    const val insetter              = "0.5.0"
+    const val lifecycle             = "2.3.1"
+    const val hilt                  = "2.37"
+    const val hiltJetpack           = "1.0.0-alpha03"
+    const val kotlin                = "1.5.21"
+    const val moshi                 = "1.12.0"
+    const val navigation            = "2.3.5"
+    const val okhttp                = "4.9.1"
+    const val sqlDelight            = "1.5.1"
+    const val toplAndroid           = "2.1.1"
 
 }
 
@@ -64,22 +65,22 @@ object Deps {
 
         object navigation {
 
-            const val fragment  = "androidx.navigation:navigation-fragment-ktx:${Versions.navigation}"
-            const val ui        = "androidx.navigation:navigation-ui-ktx:${Versions.navigation}"
+            const val fragment          = "androidx.navigation:navigation-fragment-ktx:${Versions.navigation}"
+            const val ui                = "androidx.navigation:navigation-ui-ktx:${Versions.navigation}"
 
         }
 
-        const val paging3           = "androidx.paging:paging-runtime:3.0.0"
-        const val recyclerView      = "androidx.recyclerview:recyclerview:1.2.1"
-        const val securityCrypto    = "androidx.security:security-crypto:1.1.0-alpha03"
-        const val viewBinding       = "androidx.databinding:viewbinding:${Versions.androidGradle}"
+        const val paging3               = "androidx.paging:paging-runtime:3.0.0"
+        const val recyclerView          = "androidx.recyclerview:recyclerview:1.2.1"
+        const val securityCrypto        = "androidx.security:security-crypto:1.1.0-alpha03"
+        const val viewBinding           = "androidx.databinding:viewbinding:${Versions.androidGradle}"
 
     }
 
     object chrisBanes {
 
-        const val insetter          = "dev.chrisbanes.insetter:insetter:${Versions.insetter}"
-        const val insetterWidgets   = "dev.chrisbanes.insetter:insetter-widgets:${Versions.insetter}"
+        const val insetter              = "dev.chrisbanes.insetter:insetter:${Versions.insetter}"
+        const val insetterWidgets       = "dev.chrisbanes.insetter:insetter-widgets:${Versions.insetter}"
 
     }
 
@@ -115,6 +116,12 @@ object Deps {
         const val coroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
         const val coroutinesCore    = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
         const val reflect           = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
+
+        object stdLib {
+            const val common        = "org.jetbrains.kotlin:kotlin-stdlib-common:${Versions.kotlin}"
+            const val jdk8          = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
+            const val js            = "org.jetbrains.kotlin:kotlin-stdlib-js:${Versions.kotlin}"
+        }
 
     }
 
@@ -226,15 +233,33 @@ object TestDeps {
 
 object KaptDeps {
 
+    const val kapt              = "kapt"
+
     object google {
 
-        const val hilt          = "com.google.dagger:hilt-compiler:${Versions.hilt}"
+        object hilt {
+
+            // Needed for KMP projects to specify kapt configs
+            const val group     = "com.google.dagger"
+            const val name      = "hilt-compiler"
+            const val version   = Versions.hilt
+
+            const val hilt      = "$group:$name:$version"
+
+        }
 
     }
 
     object square {
 
-        const val moshiCodegen  = "com.squareup.moshi:moshi-kotlin-codegen:${Versions.moshi}"
+        object moshiCodegen {
+
+            const val group     = "com.squareup.moshi"
+            const val name      = "moshi-kotlin-codegen"
+            const val version   = Versions.moshi
+
+            const val moshi     = "$group:$name:$version"
+        }
 
     }
 

--- a/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
+++ b/includeBuild/dependencies/src/main/kotlin/io/matthewnelson/components/dependencies/Deps.kt
@@ -178,7 +178,7 @@ object Plugins {
 
     }
 
-    const val gradleVersions    = "com.github.ben-manes:gradle-Versions-plugin:0.39.0"
+    const val gradleVersions    = "com.github.ben-manes:gradle-versions-plugin:0.39.0"
     const val intellijGradle    = "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.18"
 
     object kotlin {

--- a/includeBuild/kmp/build.gradle.kts
+++ b/includeBuild/kmp/build.gradle.kts
@@ -2,7 +2,7 @@ import io.matthewnelson.components.dependencies.Plugins
 
 plugins {
     `kotlin-dsl`
-    id("java-gradle-plugin")
+    `java-gradle-plugin`
     id("dependencies")
 }
 

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationExtension.kt
@@ -15,6 +15,8 @@
  * */
 package io.matthewnelson.components.kmp
 
+import io.matthewnelson.components.kmp.KmpTarget.Companion.COMMON_MAIN
+import io.matthewnelson.components.kmp.KmpTarget.Companion.COMMON_TEST
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.invoke
 import javax.inject.Inject
@@ -106,11 +108,11 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
         project.kotlin {
             sourceSets {
 
-                getByName(KmpTarget.COMMON_MAIN) {
+                getByName(COMMON_MAIN) {
 
                 }
 
-                getByName(KmpTarget.COMMON_TEST) {
+                getByName(COMMON_TEST) {
                     dependencies {
                         implementation(kotlin("test-common"))
                         implementation(kotlin("test-annotations-common"))
@@ -154,7 +156,7 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
 
         return if (propertyTargets != null && propertyTargets is String && propertyTargets.isNotEmpty()) {
 
-            val map: Map<String, KmpTarget> = ALL_TARGETS.associateBy { it.getCommandLinePropertyValue() }
+            val map: Map<String, KmpTarget> = ALL_TARGETS.associateBy { it.envPropertyValue }
 
             val set: Set<KmpTarget> = propertyTargets
                 .split(",")

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationExtension.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationExtension.kt
@@ -117,6 +117,11 @@ open class KmpConfigurationExtension @Inject constructor(private val project: Pr
                     maybeCreate(KmpTarget.JVM.COMMON_JVM_MAIN).dependsOn(getByName(COMMON_MAIN))
                     maybeCreate(KmpTarget.JVM.COMMON_JVM_TEST).dependsOn(getByName(COMMON_TEST))
                 }
+
+                if (targets.filterIsInstance<KmpTarget.JS>().isNotEmpty()) {
+                    maybeCreate(KmpTarget.JS.COMMON_JS_MAIN).dependsOn(getByName(COMMON_MAIN))
+                    maybeCreate(KmpTarget.JS.COMMON_JS_TEST).dependsOn(getByName(COMMON_TEST))
+                }
             }
         }
     }

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationPlugin.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationPlugin.kt
@@ -147,12 +147,12 @@ import org.gradle.api.Project
  *  - ex: `$ ./gradlew build -PKMP_TARGETS=ANDROID,JS,JVM,LINUX_X64,...`
  *
  * Or add to the global gradle.properties file (ex: ~/.gradle/gradle.properties)
- * the desired KMP_TARGET values to enable for that machine (linux, macos, windows)
+ * the desired KMP_TARGETS values to enable for that machine (linux, macos, windows)
  *
- * If no KMP_TARGET property is set, all targets that are passed to
+ * If no KMP_TARGETS property is set, all targets that are passed to
  * [KmpConfigurationExtension.setupMultiplatform] will be enabled
  *
- * Full list of KMP_TARGET property arguments:
+ * Full list of KMP_TARGETS property arguments:
  *
  *   ANDROID,JVM,
  *   JS,

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationPlugin.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpConfigurationPlugin.kt
@@ -47,11 +47,11 @@ import org.gradle.api.Project
  * }
  *
  * Append args when building from command line for the given machine (linux, macos, windows):
- *  - ex: `$ ./gradlew build -PKMP_TARGETS=ANDROID,JS_IR,JS_LEGACY,JVM,LINUX_X64,...`
+ *  - ex: `$ ./gradlew build -PKMP_TARGETS=ANDROID,JS_BROWSER,JS_NODE,JVM,LINUX_X64,...`
  *
  * Full list of KMP_TARGET property arguments:
  *
- *   ANDROID,JS_IR,JS_LEGACY,JVM,LINUX_ARM32HFP,LINUX_MIPS32,LINUX_MIPSEL32,
+ *   ANDROID,JS_BROWSER,JS_NODE,JVM,LINUX_ARM32HFP,LINUX_MIPS32,LINUX_MIPSEL32,
  *   LINUX_X64,IOS_ARM32,IOS_ARM64,IOS_X64,MACOS_X64,MINGW_X64,MINGW_X86,
  *   TVOS_ARM64,TVOS_X64,WATCHOS_ARM32,WATCHOS_ARM64,WATCHOS_X64,WATCHOS_X86
  *

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
@@ -220,7 +220,8 @@ sealed class KmpTarget {
     sealed class JS : KmpTarget() {
 
         companion object {
-            const val COMMON_JS = "commonjs"
+            const val COMMON_JS_MAIN = "commonJsMain"
+            const val COMMON_JS_TEST = "commonJsTest"
         }
 
         abstract val compilerType: KotlinJsCompilerType
@@ -262,9 +263,11 @@ sealed class KmpTarget {
 
                     sourceSets {
                         maybeCreate(sourceSetMainName).apply mainSourceSet@ {
+                            dependsOn(getByName(COMMON_JS_MAIN))
                             mainSourceSet?.invoke(this@mainSourceSet)
                         }
                         maybeCreate(sourceSetTestName).apply testSourceSet@ {
+                            dependsOn(getByName(COMMON_JS_TEST))
                             if (testSourceSet?.invoke(this@testSourceSet) == null) {
                                 dependencies {
                                     implementation(kotlin("test-js"))

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/KmpTarget.kt
@@ -33,8 +33,7 @@ sealed class KmpTarget {
     abstract val sourceSetMainName: String
     abstract val sourceSetTestName: String
 
-    @JvmSynthetic
-    internal abstract fun getCommandLinePropertyValue(): String
+    abstract val envPropertyValue: String
 
     @JvmSynthetic
     internal abstract fun setupMultiplatform(project: Project)
@@ -91,10 +90,7 @@ sealed class KmpTarget {
 
         override val sourceSetMainName: String = Companion.sourceSetMainName
         override val sourceSetTestName: String = Companion.sourceSetTestName
-
-        override fun getCommandLinePropertyValue(): String {
-            return this.javaClass.simpleName
-        }
+        override val envPropertyValue: String get() = this.javaClass.simpleName
 
         override fun setupMultiplatform(project: Project) {
             project.kotlin {
@@ -149,10 +145,7 @@ sealed class KmpTarget {
         object ARM32 : IOS() {
             override val sourceSetMainName: String = "iosArm32Main"
             override val sourceSetTestName: String = "iosArm32Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "IOS_ARM32"
-            }
+            override val envPropertyValue: String get() = "IOS_ARM32"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -168,10 +161,7 @@ sealed class KmpTarget {
         object ARM64 : IOS() {
             override val sourceSetMainName: String = "iosArm64Main"
             override val sourceSetTestName: String = "iosArm64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "IOS_ARM64"
-            }
+            override val envPropertyValue: String get() = "IOS_ARM64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -187,10 +177,7 @@ sealed class KmpTarget {
         object X64 : IOS() {
             override val sourceSetMainName: String = "iosX64Main"
             override val sourceSetTestName: String = "iosX64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "IOS_X64"
-            }
+            override val envPropertyValue: String get() = "IOS_X64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -209,22 +196,14 @@ sealed class KmpTarget {
     sealed class JS : KmpTarget() {
 
         override fun setupMultiplatform(project: Project) { /* no-op */ }
+        override val sourceSetMainName: String = "jsMain"
+        override val sourceSetTestName: String = "jsTest"
 
         object IR : JS() {
-            override val sourceSetMainName: String = "jsMain"
-            override val sourceSetTestName: String = "jsTest"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "JS_IR"
-            }
+            override val envPropertyValue: String get() = "JS_IR"
         }
         object LEGACY : JS() {
-            override val sourceSetMainName: String = IR.sourceSetMainName
-            override val sourceSetTestName: String = IR.sourceSetTestName
-
-            override fun getCommandLinePropertyValue(): String {
-                return "JS_LEGACY"
-            }
+            override val envPropertyValue: String get() = "JS_LEGACY"
         }
 
     }
@@ -232,10 +211,7 @@ sealed class KmpTarget {
     object JVM : KmpTarget() {
         override val sourceSetMainName: String = "jvmMain"
         override val sourceSetTestName: String = "jvmTest"
-
-        override fun getCommandLinePropertyValue(): String {
-            return this.javaClass.simpleName
-        }
+        override val envPropertyValue: String get() = this.javaClass.simpleName
 
         override fun setupMultiplatform(project: Project) {
             project.kotlin {
@@ -256,10 +232,7 @@ sealed class KmpTarget {
         object ARM32HFP : LINUX() {
             override val sourceSetMainName: String = "linuxArm32HfpMain"
             override val sourceSetTestName: String = "linuxArm32HfpTest"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "LINUX_ARM32HFP"
-            }
+            override val envPropertyValue: String get() = "LINUX_ARM32HFP"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -275,10 +248,7 @@ sealed class KmpTarget {
         object MIPS32 : LINUX() {
             override val sourceSetMainName: String = "linuxMips32Main"
             override val sourceSetTestName: String = "linuxMips32Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "LINUX_MIPS32"
-            }
+            override val envPropertyValue: String get() = "LINUX_MIPS32"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -294,10 +264,7 @@ sealed class KmpTarget {
         object MIPSEL32 : LINUX() {
             override val sourceSetMainName: String = "linuxMipsel32Main"
             override val sourceSetTestName: String = "linuxMipsel32Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "LINUX_MIPSEL32"
-            }
+            override val envPropertyValue: String get() = "LINUX_MIPSEL32"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -313,10 +280,7 @@ sealed class KmpTarget {
         object X64 : LINUX() {
             override val sourceSetMainName: String = "linuxX64Main"
             override val sourceSetTestName: String = "linuxX64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "LINUX_X64"
-            }
+            override val envPropertyValue: String get() = "LINUX_X64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -337,10 +301,7 @@ sealed class KmpTarget {
         object X64 : KmpTarget() {
             override val sourceSetMainName: String = "macosX64Main"
             override val sourceSetTestName: String = "macosX64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "MACOS_X64"
-            }
+            override val envPropertyValue: String get() = "MACOS_X64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -361,10 +322,7 @@ sealed class KmpTarget {
         object X64 : MINGW() {
             override val sourceSetMainName: String = "mingwX64Main"
             override val sourceSetTestName: String = "mingwX64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "MINGW_X64"
-            }
+            override val envPropertyValue: String get() = "MINGW_X64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -380,10 +338,7 @@ sealed class KmpTarget {
         object X86 : MINGW() {
             override val sourceSetMainName: String = "mingwX86Main"
             override val sourceSetTestName: String = "mingwX86Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "MINGW_X86"
-            }
+            override val envPropertyValue: String get() = "MINGW_X86"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -404,10 +359,7 @@ sealed class KmpTarget {
         object ARM64 : TVOS() {
             override val sourceSetMainName: String = "tvosArm64Main"
             override val sourceSetTestName: String = "tvosArm64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "TVOS_ARM64"
-            }
+            override val envPropertyValue: String get() = "TVOS_ARM64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -423,10 +375,7 @@ sealed class KmpTarget {
         object X64 : TVOS() {
             override val sourceSetMainName: String = "tvosX64Main"
             override val sourceSetTestName: String = "tvosX64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "TVOS_X64"
-            }
+            override val envPropertyValue: String get() = "TVOS_X64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -447,10 +396,7 @@ sealed class KmpTarget {
         object ARM32 : WATCHOS() {
             override val sourceSetMainName: String = "watchosArm32Main"
             override val sourceSetTestName: String = "watchosArm32Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "WATCHOS_ARM32"
-            }
+            override val envPropertyValue: String get() = "WATCHOS_ARM32"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -466,10 +412,7 @@ sealed class KmpTarget {
         object ARM64 : WATCHOS() {
             override val sourceSetMainName: String = "watchosArm64Main"
             override val sourceSetTestName: String = "watchosArm64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "WATCHOS_ARM64"
-            }
+            override val envPropertyValue: String get() = "WATCHOS_ARM64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -485,10 +428,7 @@ sealed class KmpTarget {
         object X64 : WATCHOS() {
             override val sourceSetMainName: String = "watchosX64Main"
             override val sourceSetTestName: String = "watchosX64Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "WATCHOS_X64"
-            }
+            override val envPropertyValue: String get() = "WATCHOS_X64"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {
@@ -504,10 +444,7 @@ sealed class KmpTarget {
         object X86 : WATCHOS() {
             override val sourceSetMainName: String = "watchosX86Main"
             override val sourceSetTestName: String = "watchosX86Test"
-
-            override fun getCommandLinePropertyValue(): String {
-                return "WATCHOS_X86"
-            }
+            override val envPropertyValue: String get() = "WATCHOS_X86"
 
             override fun setupMultiplatform(project: Project) {
                 project.kotlin {

--- a/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/TargetCallback.kt
+++ b/includeBuild/kmp/src/main/kotlin/io/matthewnelson/components/kmp/TargetCallback.kt
@@ -1,0 +1,22 @@
+/*
+*  Copyright 2021 Matthew Nelson
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+* */
+package io.matthewnelson.components.kmp
+
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+
+interface TargetCallback<T: KotlinTarget> {
+    val target: (T.() -> Unit)?
+}


### PR DESCRIPTION
This PR refactors the `kmp-configuration` plugin to:
 - Adds ability to pass callbacks for selected KmpTargets when configuring sources
 - Fix source set hierarchical structuring
 - Provide additional plugins to be applied after kmp + android plugins